### PR TITLE
Fixing case on non-windows systems

### DIFF
--- a/esp32_ILI9328_Pacman.ino
+++ b/esp32_ILI9328_Pacman.ino
@@ -54,7 +54,7 @@ byte PACMANFALLBACK = 0;
 #include <WiFi.h>
 #include <WiFiUdp.h>
 
-#include "DrawindexedMap.h"
+#include "DrawIndexedMap.h"
 #define CS 5
 #define RESET 17
 ili9328SPI tft(CS, RESET);


### PR DESCRIPTION
Got this dreadful error message when compiling from Arduino on Ubuntu Linux:

```
esp32_ILI9328_Pacman.ino:59:28: fatal error: DrawindexedMap.h: No such file or directory
compilation terminated.
```

Putting the right the case in the file include did the fix.